### PR TITLE
[systemd] crash-reporter.service started later and no dbus waited

### DIFF
--- a/data/crash-reporter.service
+++ b/data/crash-reporter.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=Crash file reporter daemon
 Requires=dbus.service
+After=user-session.target
 
 [Service]
 ExecStart=/usr/bin/crash-reporter-daemon
-Type=dbus
-BusName=com.nokia.CrashReporter.Daemon
+Type=simple
 Restart=always
 
 [Install]
-WantedBy=user-session.target
+WantedBy=post-user-session.target


### PR DESCRIPTION
User session start hit timeout because crash-reporter.service start was delayed by 30s.
Crash-reporter has 30s internal wait before it starts and systemd waited it to acquire dbus name. Because crash reporter was part of user-session it delayed whole boot readiness by that 30s. This change removes systemd wait for crash-reporter to accuire dbus name before it is considered ready.  Also start is moved to post-session.

Signed-off-by: Pekka Lundstrom pekka.lundstrom@jollamobile.com
