### PR TITLE
[crash-reporter] Make crash-reporter boosting with qt5.

### DIFF
--- a/data/crash-reporter.service
+++ b/data/crash-reporter.service
@@ -5,7 +5,7 @@ After=user-session.target
 ConditionPathExists=!/tmp/os-update-running
 
 [Service]
-ExecStart=/usr/bin/crash-reporter-daemon
+ExecStart=/usr/bin/invoker -o --type=qt5 /usr/bin/crash-reporter-daemon
 Type=simple
 Restart=always
 

--- a/rpm/crash-reporter.spec
+++ b/rpm/crash-reporter.spec
@@ -23,6 +23,7 @@ BuildRequires:          pkgconfig(dbus-1)
 BuildRequires:          pkgconfig(libiphb)
 BuildRequires:          pkgconfig(libudev)
 BuildRequires:          pkgconfig(mce)
+BuildRequires:          pkgconfig(qt5-boostable)
 Requires:               sp-rich-core >= 1.71.2
 Requires:               sp-endurance
 Requires:               oneshot

--- a/src/daemon/daemon.pro
+++ b/src/daemon/daemon.pro
@@ -31,6 +31,13 @@ CONFIG += link_pkgconfig
 PKGCONFIG += \
     libudev
 
+packagesExist(qt5-boostable) {
+    DEFINES += HAS_BOOSTER
+    PKGCONFIG += qt5-boostable
+} else {
+    warning("qt5-boostable not available; startup times will be slower")
+}
+
 INCLUDEPATH += . \
                ../libs/coredir \
                ../libs/httpclient \

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -100,7 +100,7 @@ void signalHandler(int signal) {
   * @param argc Argument count.
   * @param argv Arguments.
   */
-int main(int argc, char **argv)
+Q_DECL_EXPORT int main(int argc, char **argv)
 {
     signal(SIGINT, &signalHandler);
     signal(SIGTERM, &signalHandler);


### PR DESCRIPTION
Before boosting:

[root@Jolla nemo]# ./smaps -p 11325

```
          Total:  211 mappings

           Size:  49824 kB
            Rss:  6580 kB
            Pss:  1268 kB
   Shared_Clean:  5544 kB
   Shared_Dirty:  0 kB
  Private_Clean:  256 kB
  Private_Dirty:  780 kB
     Referenced:  6580 kB
      Anonymous:  780 kB
  AnonHugePages:  0 kB
           Swap:  0 kB
 KernelPageSize:  4 kB
    MMUPageSize:  4 kB
         Locked:  0 kB
```

root@Jolla nemo]# ./smaps -p 10885

```
          Total:  223 mappings

           Size:  50044 kB
            Rss:  5284 kB
            Pss:  762 kB
   Shared_Clean:  4220 kB
   Shared_Dirty:  472 kB
  Private_Clean:  256 kB
  Private_Dirty:  336 kB
     Referenced:  4960 kB
      Anonymous:  808 kB
  AnonHugePages:  0 kB
           Swap:  0 kB
 KernelPageSize:  4 kB
    MMUPageSize:  4 kB
         Locked:  0 kB
```

after ^^

Signed-off-by: Carsten Munk carsten.munk@jollamobile.com
