### PR TITLE
Fix service started not showing on text switch element + cleanups

### DIFF
--- a/src/sailfishui/PendingUploads.qml
+++ b/src/sailfishui/PendingUploads.qml
@@ -21,7 +21,6 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
-import Sailfish.Silica.theme 1.0
 import com.jolla.settings.crashreporter 1.0
 
 Page {

--- a/src/sailfishui/crash-reporter.qml
+++ b/src/sailfishui/crash-reporter.qml
@@ -21,7 +21,6 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
-import Sailfish.Silica.theme 1.0
 import com.jolla.settings.crashreporter 1.0
 
 Page {

--- a/src/sailfishui/plugin/PrivacyNotice.qml
+++ b/src/sailfishui/plugin/PrivacyNotice.qml
@@ -24,7 +24,7 @@ import Sailfish.Silica 1.0
 import com.jolla.settings.crashreporter 1.0
 
 Item {
-    property bool declined: false
+    property bool declined
 
     Component.onCompleted: {
         parent.statusChanged.connect(pageStatusChanged)

--- a/src/sailfishui/plugin/PrivacyNotice.qml
+++ b/src/sailfishui/plugin/PrivacyNotice.qml
@@ -21,7 +21,6 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
-import Sailfish.Silica.theme 1.0
 import com.jolla.settings.crashreporter 1.0
 
 Item {

--- a/src/sailfishui/plugin/org.freedesktop.systemd1.Manager.xml
+++ b/src/sailfishui/plugin/org.freedesktop.systemd1.Manager.xml
@@ -40,5 +40,13 @@
    <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QList&lt;UnitFileChange&gt;"/>
    <arg name="changes" type="a(sss)" direction="out"/>
   </method>
+  <signal name="UnitNew">
+   <arg name="id" type="s"/>
+   <arg name="path" type="o"/>
+  </signal>
+  <signal name="UnitRemoved">
+   <arg name="id" type="s"/>
+   <arg name="path" type="o"/>
+  </signal>
  </interface>
 </node>

--- a/src/sailfishui/plugin/plugin.pro
+++ b/src/sailfishui/plugin/plugin.pro
@@ -39,3 +39,5 @@ SOURCES += \
 	unitfilechange.cpp
 
 INSTALLS += target qml
+
+OTHER_FILES = *.qml

--- a/src/sailfishui/plugin/systemdservice.cpp
+++ b/src/sailfishui/plugin/systemdservice.cpp
@@ -98,7 +98,7 @@ void SystemdServicePrivate::gotUnitPath(QDBusPendingCallWatcher *call)
 
     QDBusPendingReply<QDBusObjectPath> reply = *call;
     if (reply.isError()) {
-        qDebug() << "Failed to get crash-reporter.service DBus path"
+        qDebug() << "Failed to get DBus path for unit" << serviceName << ":"
                  << reply.error().name() << reply.error().message();
     } else {
         QString path = reply.argumentAt<0>().path();
@@ -106,11 +106,11 @@ void SystemdServicePrivate::gotUnitPath(QDBusPendingCallWatcher *call)
         unit = new OrgFreedesktopSystemd1UnitInterface("org.freedesktop.systemd1",
                 path, manager->connection(), q);
 
-        OrgFreedesktopDBusPropertiesInterface *crashReporterProperties =
+        OrgFreedesktopDBusPropertiesInterface *unitProperties =
                 new OrgFreedesktopDBusPropertiesInterface("org.freedesktop.systemd1",
                         path, manager->connection(), q);
 
-        QObject::connect(crashReporterProperties,SIGNAL(PropertiesChanged(const QString &, const QVariantMap &, const QStringList &)),
+        QObject::connect(unitProperties,SIGNAL(PropertiesChanged(const QString &, const QVariantMap &, const QStringList &)),
                          q, SLOT(propertiesChanged(const QString &, const QVariantMap &, const QStringList &)));
 
         /* Before we create a unit proxy, we 'guess' service is not running. Now

--- a/src/sailfishui/plugin/systemdservice.cpp
+++ b/src/sailfishui/plugin/systemdservice.cpp
@@ -67,12 +67,14 @@ void SystemdServicePrivate::initializeDBusInterface()
     manager = new OrgFreedesktopSystemd1ManagerInterface("org.freedesktop.systemd1",
             "/org/freedesktop/systemd1", connection, q);
 
+    // FIXME: this shouldn't really be here, instead e.g. reload on package update scripts.
+    // Now it's done for every instance of different services
     /* Ensure systemd configuration is up to date with unit files, for example
      * after change by package update. */
     QDBusPendingCall reply = manager->Reload();
     reply.waitForFinished();
     if (reply.isError()) {
-        qDebug() << "Couldn't reload systemd unit files";
+        qDebug() << "Couldn't reload systemd unit files" << reply.error().type() << reply.error().message();
     }
 
     qDBusRegisterMetaType<UnitFileChange>();
@@ -82,7 +84,7 @@ void SystemdServicePrivate::initializeDBusInterface()
     reply = manager->Subscribe();
     reply.waitForFinished();
     if (reply.isError()) {
-        qDebug() << "Couldn't subscribe to systemd manager";
+        qDebug() << "Couldn't subscribe to systemd manager" << reply.error().type() << reply.error().message();
     }
 
     reply = manager->LoadUnit(serviceName);

--- a/src/sailfishui/plugin/systemdservice.cpp
+++ b/src/sailfishui/plugin/systemdservice.cpp
@@ -57,7 +57,8 @@ private:
     void changeState(const QString &state);
 };
 
-void SystemdServicePrivate::initializeDBusInterface() {
+void SystemdServicePrivate::initializeDBusInterface()
+{
     Q_Q(SystemdService);
 
     QDBusConnection connection = (managerType == SystemdService::UserManager) ?
@@ -91,7 +92,8 @@ void SystemdServicePrivate::initializeDBusInterface() {
                      q, SLOT(gotUnitPath(QDBusPendingCallWatcher *)));
 }
 
-void SystemdServicePrivate::gotUnitPath(QDBusPendingCallWatcher *call) {
+void SystemdServicePrivate::gotUnitPath(QDBusPendingCallWatcher *call)
+{
     Q_Q(SystemdService);
 
     QDBusPendingReply<QDBusObjectPath> reply = *call;
@@ -128,7 +130,8 @@ void SystemdServicePrivate::gotUnitPath(QDBusPendingCallWatcher *call) {
 
 void SystemdServicePrivate::propertiesChanged(const QString &interface,
                                               const QVariantMap &changedProperties,
-                                              const QStringList &invalidatedProperties) {
+                                              const QStringList &invalidatedProperties)
+{
     Q_Q(SystemdService);
 
     if (interface != OrgFreedesktopSystemd1UnitInterface::staticInterfaceName())
@@ -154,7 +157,8 @@ void SystemdServicePrivate::propertiesChanged(const QString &interface,
     }
 }
 
-void SystemdServicePrivate::stateChanged(QDBusPendingCallWatcher *call) {
+void SystemdServicePrivate::stateChanged(QDBusPendingCallWatcher *call)
+{
     QDBusPendingReply<QDBusObjectPath> reply = *call;
     if (reply.isError()) {
         qDebug() << "Couldn't change systemd service state"
@@ -164,7 +168,8 @@ void SystemdServicePrivate::stateChanged(QDBusPendingCallWatcher *call) {
     call->deleteLater();
 }
 
-void SystemdServicePrivate::unitFileStateChanged(QDBusPendingCallWatcher *call) {
+void SystemdServicePrivate::unitFileStateChanged(QDBusPendingCallWatcher *call)
+{
     QDBusPendingCall reply = *call;
     if (reply.isError()) {
         qDebug() << "Couldn't enable or disable a unit file"
@@ -174,7 +179,8 @@ void SystemdServicePrivate::unitFileStateChanged(QDBusPendingCallWatcher *call) 
     call->deleteLater();
 }
 
-void SystemdServicePrivate::maskingChanged(QDBusPendingCallWatcher *call) {
+void SystemdServicePrivate::maskingChanged(QDBusPendingCallWatcher *call)
+{
     QDBusPendingCall reply = *call;
     if (reply.isError()) {
         qDebug() << "Couldn't mask or unmask a unit file"
@@ -186,7 +192,8 @@ void SystemdServicePrivate::maskingChanged(QDBusPendingCallWatcher *call) {
     call->deleteLater();
 }
 
-void SystemdServicePrivate::reload() {
+void SystemdServicePrivate::reload()
+{
     Q_Q(SystemdService);
 
     QDBusPendingCallWatcher *watcher =
@@ -196,7 +203,8 @@ void SystemdServicePrivate::reload() {
                      q, SLOT(reloaded(QDBusPendingCallWatcher *)));
 }
 
-void SystemdServicePrivate::reloaded(QDBusPendingCallWatcher *call) {
+void SystemdServicePrivate::reloaded(QDBusPendingCallWatcher *call)
+{
     Q_Q(SystemdService);
 
     QDBusPendingCall reply = *call;
@@ -212,7 +220,8 @@ void SystemdServicePrivate::reloaded(QDBusPendingCallWatcher *call) {
     call->deleteLater();
 }
 
-void SystemdServicePrivate::changeState(const QString &state) {
+void SystemdServicePrivate::changeState(const QString &state)
+{
     Q_Q(SystemdService);
 
     SystemdService::State newState;
@@ -233,7 +242,8 @@ void SystemdServicePrivate::changeState(const QString &state) {
 }
 
 SystemdService::SystemdService(QObject *parent):
-  QObject(parent), d_ptr(new SystemdServicePrivate) {
+  QObject(parent), d_ptr(new SystemdServicePrivate)
+{
     Q_D(SystemdService);
     d->q_ptr = this;
     d->managerType = UserManager;
@@ -243,13 +253,15 @@ SystemdService::SystemdService(QObject *parent):
     d->unit = 0;
 }
 
-QString SystemdService::serviceName() const {
+QString SystemdService::serviceName() const
+{
     Q_D(const SystemdService);
 
     return d->serviceName;
 }
 
-void SystemdService::setServiceName(const QString& serviceName) {
+void SystemdService::setServiceName(const QString& serviceName)
+{
     Q_D(SystemdService);
 
     if (!d->serviceName.isEmpty()) {
@@ -263,13 +275,15 @@ void SystemdService::setServiceName(const QString& serviceName) {
     }
 }
 
-SystemdService::ManagerType SystemdService::managerType() const {
+SystemdService::ManagerType SystemdService::managerType() const
+{
     Q_D(const SystemdService);
 
     return d->managerType;
 }
 
-void SystemdService::setManagerType(SystemdService::ManagerType managerType) {
+void SystemdService::setManagerType(SystemdService::ManagerType managerType)
+{
     Q_D(SystemdService);
 
     if (d->managerType != managerType) {
@@ -278,13 +292,15 @@ void SystemdService::setManagerType(SystemdService::ManagerType managerType) {
     }
 }
 
-SystemdService::State SystemdService::state() const {
+SystemdService::State SystemdService::state() const
+{
     Q_D(const SystemdService);
 
     return d->state;
 }
 
-void SystemdService::start() {
+void SystemdService::start()
+{
     Q_D(SystemdService);
 
     if (!d->unit) {
@@ -302,7 +318,8 @@ void SystemdService::start() {
             this, SLOT(stateChanged(QDBusPendingCallWatcher *)));
 }
 
-void SystemdService::stop() {
+void SystemdService::stop()
+{
     Q_D(SystemdService);
 
     if (!d->unit) {
@@ -320,13 +337,15 @@ void SystemdService::stop() {
             this, SLOT(stateChanged(QDBusPendingCallWatcher *)));
 }
 
-bool SystemdService::enabled() const {
+bool SystemdService::enabled() const
+{
     Q_D(const SystemdService);
 
     return (d->unit && d->unit->unitFileState() == "enabled");
 }
 
-void SystemdService::setEnabled(bool state) {
+void SystemdService::setEnabled(bool state)
+{
     Q_D(SystemdService);
 
     QDBusPendingCallWatcher *watcher;
@@ -351,7 +370,8 @@ void SystemdService::setEnabled(bool state) {
             this, SLOT(unitFileStateChanged(QDBusPendingCallWatcher *)));
 }
 
-void SystemdService::setMasked(bool state) {
+void SystemdService::setMasked(bool state)
+{
     Q_D(SystemdService);
 
     if (masked() == state)
@@ -379,7 +399,8 @@ void SystemdService::setMasked(bool state) {
             this, SLOT(maskingChanged(QDBusPendingCallWatcher *)));
 }
 
-bool SystemdService::masked() const {
+bool SystemdService::masked() const
+{
     Q_D(const SystemdService);
 
     return (d->unit && d->unit->loadState() == "masked");
@@ -387,7 +408,8 @@ bool SystemdService::masked() const {
 
 void SystemdService::classBegin() {}
 
-void SystemdService::componentComplete() {
+void SystemdService::componentComplete()
+{
     Q_D(SystemdService);
 
     if (d->serviceName.isEmpty()) {
@@ -398,7 +420,8 @@ void SystemdService::componentComplete() {
     d->initializeDBusInterface();
 }
 
-SystemdService::~SystemdService() {
+SystemdService::~SystemdService()
+{
     Q_D(SystemdService);
 
     /* Properly unsubscribe from receiving DBus signals in order to stop systemd

--- a/src/sailfishui/plugin/systemdservice.h
+++ b/src/sailfishui/plugin/systemdservice.h
@@ -96,6 +96,9 @@ private:
     Q_PRIVATE_SLOT(d_func(), void propertiesChanged(const QString &,
                                                     const QVariantMap &,
                                                     const QStringList &));
+    Q_PRIVATE_SLOT(d_func(), void handleUnitNew(const QString &, const QDBusObjectPath &));
+    Q_PRIVATE_SLOT(d_func(), void handleUnitRemoved(const QString &, const QDBusObjectPath &));
+    Q_PRIVATE_SLOT(d_func(), void checkUnitState());
 };
 
 #endif // SYSTEMDSERVICE_H


### PR DESCRIPTION
See last commit for details. This could still get more love for robust Systemd tracking, but this already makes it work. Could some day avoid unnecessary reloads, property access that both blocks and creates temporary Systemd units, etc.

@rainemak perhaps?