### PR TITLE
[crash-reporter] Fix build with systemd v233. Contributes to JB#45921

### DIFF
--- a/rpm/crash-reporter.spec
+++ b/rpm/crash-reporter.spec
@@ -22,6 +22,7 @@ BuildRequires:          ssu-devel
 BuildRequires:          pkgconfig(dbus-1)
 BuildRequires:          pkgconfig(libiphb)
 BuildRequires:          pkgconfig(libudev)
+BuildRequires:          pkgconfig(libsystemd)
 BuildRequires:          pkgconfig(mce)
 BuildRequires:          pkgconfig(qt5-boostable)
 BuildRequires:          pkgconfig(nemonotifications-qt5)

--- a/src/journalspy/journalspy.pro
+++ b/src/journalspy/journalspy.pro
@@ -42,7 +42,7 @@ LIBS += \
 	../../lib/libcrashreporter.so \
 
 PKGCONFIG += \
-	libsystemd-journal \
+	libsystemd \
 
 target.path = $$CREPORTER_SYSTEM_LIBEXEC
 


### PR DESCRIPTION
Replace: libsystemd-journal -> libsystemd.
Add: BuildRequires: pkgconfig(libsystemd).

Signed-off-by: Igor Zhbanov <i.zhbanov@omprussia.ru>